### PR TITLE
defined url_defaults to an empty dict instead of None

### DIFF
--- a/src/flask/sansio/blueprints.py
+++ b/src/flask/sansio/blueprints.py
@@ -180,9 +180,9 @@ class Blueprint(Scaffold):
         template_folder: str | os.PathLike | None = None,
         url_prefix: str | None = None,
         subdomain: str | None = None,
-        url_defaults: dict | None = None,
-        root_path: str | None = None,
-        cli_group: str | None = _sentinel,  # type: ignore
+        url_defaults: dict | None = {},
+        root_path: str | None = {},
+        cli_group: str | None = _sentinel,    # type: ignore
     ):
         super().__init__(
             import_name=import_name,
@@ -202,9 +202,6 @@ class Blueprint(Scaffold):
         self.url_prefix = url_prefix
         self.subdomain = subdomain
         self.deferred_functions: list[DeferredSetupFunction] = []
-
-        if url_defaults is None:
-            url_defaults = {}
 
         self.url_values_defaults = url_defaults
         self.cli_group = cli_group


### PR DESCRIPTION
Changed 

`url_defaults: dict | None = None,`

to 

`url_defaults: dict | None = {},`

which makes url_defaults an empty dictionary from the beginning to avoid checking it later with:


```
        if url_defaults is None:
            url_defaults = {}
```

